### PR TITLE
eslint tweaks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+build
+vendor

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
   ],
   "rules": {
     "indent": "off",
+    "react/no-unescaped-entities": ["error", {"forbid": [">", "}"]}],
     "@typescript-eslint/indent": [
       "error",
       2,


### PR DESCRIPTION
* Ignore vendor and build directories
* Allow apostrophes in jsx markup

There are still a few warnings: it's `@typescript-eslint/no-unused-vars` and there appears to be a [bug](https://github.com/typescript-eslint/typescript-eslint/issues/46) in typescript-eslint.