### PR TITLE
Add a simple API handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,37 @@
 
 User interface for MetalKube
 
+## Getting started
+
+* Install [yarn][1] and [golang][2]
+* Set up your `$GOPATH` (this means selecting a directory on your computer where
+  all your golang code will go, and setting the `GOPATH` environment variable to
+  that path)
+* Clone this repository to your `$GOPATH` directory, i.e.
+  `$GOPATH/src/github.com/metalkube/facet` (create the `src` and `github.com`
+  directories if they don't already exist)
+* `cd` into it
+* Install javascript dependencies with `yarn install`
+* Start the backend server with `go run main.go server`
+* Start the yarn server with `yarn start`
+* Open the UI at `http://localhost:3000`
+
+[1]: https://yarnpkg.com/en/
+[2]: https://golang.org/
+
 ## Running the production server
 
 ```
 $ go run main.go server
 ```
+
+## Running the development server
+
+During development, you can take advantage of using the Golang server.  It
+provides a REST API layer (e.g. `/api/hosts`)
+
+To use it, start the `yarn start` server in one tab, and then start the Golang
+server with `go run main.go server` in another tab.
 
 ## Available Scripts
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -15,35 +15,31 @@
 package server
 
 import (
-	"github.com/metalkube/facet/pkg/server"
-	"github.com/spf13/cobra"
+	"encoding/json"
+	"fmt"
+	"net/http"
 )
 
-var args struct {
-	port string
+type Host struct {
+	Id string `json:"id"`
 }
 
-// Cmd is the cobra serve command
-var Cmd = &cobra.Command{
-	Use:   "server",
-	Short: "Run the facet server",
-	Long:  "Run the facet server.",
-	Run:   run,
+type ApiResponse struct {
+	Data interface{} `json:"data"`
 }
 
-func init() {
-	flags := Cmd.Flags()
-	flags.StringVar(
-		&args.port,
-		"port",
-		"8080",
-		"The port of the facet server",
-	)
-}
-
-func run(cmd *cobra.Command, argv []string) {
-	s := server.Server{
-		Port: args.port,
+func respondWithJson(w http.ResponseWriter, obj interface{}) {
+	resp := ApiResponse{Data: obj}
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		fmt.Fprint(w, err)
 	}
-	s.Start()
+}
+
+func HostsHandler(w http.ResponseWriter, r *http.Request) {
+	hostList := [2]Host{
+		Host{Id: "host-01"},
+		Host{Id: "host-02"},
+	}
+	respondWithJson(w, hostList)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,51 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+type Server struct {
+	Port string
+}
+
+func jsonMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) Start() {
+	router := mux.NewRouter()
+
+	// API router; add new routes here
+	api := router.PathPrefix("/api").Subrouter()
+	api.Use(jsonMiddleware)
+	api.HandleFunc("/hosts", HostsHandler)
+
+	// Serving the build/ directory from the / root of the app
+	staticFileDirectory := http.Dir("./build/")
+	staticFileHandler := http.StripPrefix("/", http.FileServer(staticFileDirectory))
+	router.PathPrefix("/").Handler(staticFileHandler).Methods("GET")
+
+	fmt.Println("Server started at http://localhost:" + s.Port)
+	http.ListenAndServe(":"+s.Port, router)
+
+}


### PR DESCRIPTION
During development, you can take advantage of using the Golang server.  The server does two things:

* It provides a REST API layer (e.g. `/api/nodes`)
* It reverse-proxies requests to the `react-scripts` development server

To use it, start the `yarn start` server in one tab, and then start the Golang server with `go run main.go server --use-proxy` in another tag.  This way you can access both from a single hostname and port.
