### PR TITLE
Add a production build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+bin

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:ea0700160aca4ef099f4e06686a665a87691f4248dddd40796925eda2e46bd64"
+  name = "github.com/rakyll/statik"
+  packages = ["fs"]
+  pruneopts = "UT"
+  revision = "1355192d24db2566a83c3914e187e2a7e7679832"
+  version = "v0.1.5"
+
+[[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
   name = "github.com/spf13/cobra"
   packages = ["."]
@@ -38,6 +46,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/gorilla/mux",
+    "github.com/rakyll/statik/fs",
     "github.com/spf13/cobra",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,3 +36,7 @@
 [[constraint]]
   name = "github.com/gorilla/mux"
   version = "1.7.0"
+
+[[constraint]]
+  name = "github.com/rakyll/statik"
+  version = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,39 @@ server with `go run main.go server` in another tab.
 The development server will recognize non static asset requests (e.g. `fetch('/api/hosts')`),
 and will proxy it to API server (`http://localhost:8080/api/hosts`) as a fallback.
 
+## Production build
+
+You can compile the production executable by running:
+
+```
+$ ./build.sh
+```
+
+This uses the [statik][3] utility to bundle all of the static assets from
+`./build/` into a golang source file.  It then compiles the project into a
+single binary, and places it into `bin/`.
+
+You can use the binary directly:
+
+```
+./bin/facet -h
+facet server
+
+Usage:
+  facet [command]
+
+Available Commands:
+  help        Help about any command
+  server      Run the facet server
+
+Flags:
+  -h, --help   help for facet
+
+Use "facet [command] --help" for more information about a command.
+```
+
+[3]: https://github.com/rakyll/statik
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+[ -f $GOPATH/bin/statik ] || {
+    echo "I require the statik program but it's not installed.  Aborting.";
+    echo "You can install it with 'go get github.com/rakyll/statik'";
+    exit 1;
+}
+
+set -ex
+
+yarn build
+statik -f -src build
+go build main.go
+mkdir -p bin
+mv main bin/facet
+git checkout statik/statik.go

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,8 @@ package server
 import (
 	"fmt"
 	"github.com/gorilla/mux"
+	_ "github.com/metalkube/facet/statik"
+	"github.com/rakyll/statik/fs"
 	"net/http"
 )
 
@@ -40,9 +42,15 @@ func (s *Server) Start() {
 	api.Use(jsonMiddleware)
 	api.HandleFunc("/hosts", HostsHandler)
 
-	// Serving the build/ directory from the / root of the app
-	staticFileDirectory := http.Dir("./build/")
-	staticFileHandler := http.StripPrefix("/", http.FileServer(staticFileDirectory))
+	// Attempt to get the statik-built bundle
+	statikFS, err := fs.New()
+
+	if err != nil {
+		// Statik data isn't present, serve files from './build'
+		statikFS = http.Dir("./build/")
+	}
+
+	staticFileHandler := http.StripPrefix("/", http.FileServer(statikFS))
 	router.PathPrefix("/").Handler(staticFileHandler).Methods("GET")
 
 	fmt.Println("Server started at http://localhost:" + s.Port)

--- a/statik/statik.go
+++ b/statik/statik.go
@@ -1,0 +1,10 @@
+package statik
+
+import (
+	"github.com/rakyll/statik/fs"
+)
+
+func init() {
+	data := ""
+	fs.Register(data)
+}

--- a/vendor/github.com/rakyll/statik/LICENSE
+++ b/vendor/github.com/rakyll/statik/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014 Google Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/rakyll/statik/fs/fs.go
+++ b/vendor/github.com/rakyll/statik/fs/fs.go
@@ -1,0 +1,172 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fs contains an HTTP file system that works with zip contents.
+package fs
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+var zipData string
+
+// file holds unzipped read-only file contents and file metadata.
+type file struct {
+	os.FileInfo
+	data []byte
+	fs   *statikFS
+}
+
+type statikFS struct {
+	files map[string]file
+}
+
+// Register registers zip contents data, later used to initialize
+// the statik file system.
+func Register(data string) {
+	zipData = data
+}
+
+// New creates a new file system with the registered zip contents data.
+// It unzips all files and stores them in an in-memory map.
+func New() (http.FileSystem, error) {
+	if zipData == "" {
+		return nil, errors.New("statik/fs: no zip data registered")
+	}
+	zipReader, err := zip.NewReader(strings.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return nil, err
+	}
+	files := make(map[string]file, len(zipReader.File))
+	fs := &statikFS{files: files}
+	for _, zipFile := range zipReader.File {
+		fi := zipFile.FileInfo()
+		f := file{FileInfo: fi, fs: fs}
+		f.data, err = unzip(zipFile)
+		if err != nil {
+			return nil, fmt.Errorf("statik/fs: error unzipping file %q: %s", zipFile.Name, err)
+		}
+		files["/"+zipFile.Name] = f
+	}
+	for fn := range files {
+		dn := path.Dir(fn)
+		if _, ok := files[dn]; !ok {
+			files[dn] = file{FileInfo: dirInfo{dn}, fs: fs}
+		}
+	}
+	return fs, nil
+}
+
+var _ = os.FileInfo(dirInfo{})
+
+type dirInfo struct {
+	name string
+}
+
+func (di dirInfo) Name() string       { return di.name }
+func (di dirInfo) Size() int64        { return 0 }
+func (di dirInfo) Mode() os.FileMode  { return 0755 | os.ModeDir }
+func (di dirInfo) ModTime() time.Time { return time.Time{} }
+func (di dirInfo) IsDir() bool        { return true }
+func (di dirInfo) Sys() interface{}   { return nil }
+
+func unzip(zf *zip.File) ([]byte, error) {
+	rc, err := zf.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return ioutil.ReadAll(rc)
+}
+
+// Open returns a file matching the given file name, or os.ErrNotExists if
+// no file matching the given file name is found in the archive.
+// If a directory is requested, Open returns the file named "index.html"
+// in the requested directory, if that file exists.
+func (fs *statikFS) Open(name string) (http.File, error) {
+	name = strings.Replace(name, "//", "/", -1)
+	if f, ok := fs.files[name]; ok {
+		return newHTTPFile(f), nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func newHTTPFile(file file) *httpFile {
+	if file.IsDir() {
+		return &httpFile{file: file, isDir: true}
+	}
+	return &httpFile{file: file, reader: bytes.NewReader(file.data)}
+}
+
+// httpFile represents an HTTP file and acts as a bridge
+// between file and http.File.
+type httpFile struct {
+	file
+
+	reader *bytes.Reader
+	isDir  bool
+}
+
+// Read reads bytes into p, returns the number of read bytes.
+func (f *httpFile) Read(p []byte) (n int, err error) {
+	if f.reader == nil && f.isDir {
+		return 0, io.EOF
+	}
+	return f.reader.Read(p)
+}
+
+// Seek seeks to the offset.
+func (f *httpFile) Seek(offset int64, whence int) (ret int64, err error) {
+	return f.reader.Seek(offset, whence)
+}
+
+// Stat stats the file.
+func (f *httpFile) Stat() (os.FileInfo, error) {
+	return f, nil
+}
+
+// IsDir returns true if the file location represents a directory.
+func (f *httpFile) IsDir() bool {
+	return f.isDir
+}
+
+// Readdir returns an empty slice of files, directory
+// listing is disabled.
+func (f *httpFile) Readdir(count int) ([]os.FileInfo, error) {
+	var fis []os.FileInfo
+	if !f.isDir {
+		return fis, nil
+	}
+	prefix := f.Name()
+	for fn, f := range f.file.fs.files {
+		if strings.HasPrefix(fn, prefix) && len(fn) > len(prefix) {
+			fis = append(fis, f.FileInfo)
+		}
+	}
+	return fis, nil
+}
+
+func (f *httpFile) Close() error {
+	return nil
+}

--- a/vendor/github.com/rakyll/statik/fs/walk.go
+++ b/vendor/github.com/rakyll/statik/fs/walk.go
@@ -1,0 +1,79 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"path"
+	"path/filepath"
+)
+
+// Walk walks the file tree rooted at root,
+// calling walkFn for each file or directory in the tree, including root.
+// All errors that arise visiting files and directories are filtered by walkFn.
+//
+// As with filepath.Walk, if the walkFn returns filepath.SkipDir, then the directory is skipped.
+func Walk(hfs http.FileSystem, root string, walkFn filepath.WalkFunc) error {
+	dh, err := hfs.Open(root)
+	if err != nil {
+		return err
+	}
+	di, err := dh.Stat()
+	if err != nil {
+		return err
+	}
+	fis, err := dh.Readdir(-1)
+	dh.Close()
+	if err = walkFn(root, di, err); err != nil {
+		if err == filepath.SkipDir {
+			return nil
+		}
+		return err
+	}
+	for _, fi := range fis {
+		fn := path.Join(root, fi.Name())
+		if fi.IsDir() {
+			if err = Walk(hfs, fn, walkFn); err != nil {
+				if err == filepath.SkipDir {
+					continue
+				}
+				return err
+			}
+			continue
+		}
+		if err = walkFn(fn, fi, nil); err != nil {
+			if err == filepath.SkipDir {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadFile reads the contents of the file of hfs specified by name.
+// Just as ioutil.ReadFile does.
+func ReadFile(hfs http.FileSystem, name string) ([]byte, error) {
+	fh, err := hfs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, fh)
+	fh.Close()
+	return buf.Bytes(), err
+}


### PR DESCRIPTION
This is branched from #9. Once that PR is merged, this will need to be rebased on top of master.

This adds a script to produce a production binary for the facet server.

The README now contains documentation for this process.