### PR TITLE
Add an API endpoint for booting the bootstrap VM

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,0 +1,63 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"github.com/satori/go.uuid"
+	"time"
+)
+
+type NotificationStatus int
+
+const (
+	SUCCESS NotificationStatus = 0
+	RUNNING NotificationStatus = 1
+	FAILURE NotificationStatus = 2
+)
+
+func (ns NotificationStatus) String() string {
+	values := [...]string{
+		"SUCCESS",
+		"RUNNING",
+		"FAILURE",
+	}
+	if ns < SUCCESS || ns > FAILURE {
+		return "Unknown"
+	}
+
+	return values[ns]
+}
+
+func (ns NotificationStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ns.String())
+}
+
+type Notification struct {
+	Id        string             `json:"id"`
+	Message   string             `json:"message"`
+	Status    NotificationStatus `json:"status"`
+	Timestamp time.Time          `json:"timestamp"`
+}
+
+func NewNotification(message string, status NotificationStatus) Notification {
+	uuid := uuid.NewV4()
+	return Notification{
+		Id:        uuid.String(),
+		Message:   message,
+		Status:    status,
+		Timestamp: time.Now(),
+	}
+}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -61,3 +61,8 @@ func NewNotification(message string, status NotificationStatus) Notification {
 		Timestamp: time.Now(),
 	}
 }
+
+func NewNotificationChannel() chan Notification {
+	return make(chan Notification, 10)
+
+}

--- a/pkg/integration/bootstrap_vm.go
+++ b/pkg/integration/bootstrap_vm.go
@@ -1,0 +1,49 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"github.com/metalkube/facet/pkg/common"
+	"log"
+	"os/exec"
+)
+
+const (
+	// This command refers to the shell script in the dev-scripts repository.
+	deployBoostrapVMCommand = "./05_deploy_bootstrap_vm.sh"
+)
+
+func CreateBootstrapVM(notificationChannel chan common.Notification) {
+	log.Print("Booting bootstrap VM")
+
+	n := common.NewNotification("Booting bootstrap VM", common.RUNNING)
+	notificationChannel <- n
+
+	cmd := exec.Command(deployBoostrapVMCommand)
+	out, err := cmd.Output()
+
+	if err != nil {
+		m := fmt.Sprintf("Bootstrap VM failed to boot: %q", out)
+		n := common.NewNotification(m, common.FAILURE)
+		log.Print(m)
+		notificationChannel <- n
+		return
+	}
+
+	log.Print("Bootstrap VM booted")
+	n = common.NewNotification("Bootstrap VM booted", common.SUCCESS)
+	notificationChannel <- n
+}

--- a/pkg/integration/example.go
+++ b/pkg/integration/example.go
@@ -1,0 +1,34 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"github.com/metalkube/facet/pkg/common"
+	"time"
+)
+
+// This is an example of a task that might take a while to finish.  It takes a
+// Notification channel as an argument.  You can use this channel to send
+// Notification messages to the browser.
+func PerformLongTask(notificationChannel chan common.Notification) {
+	n := common.NewNotification("Started a long running task", common.RUNNING)
+	notificationChannel <- n
+
+	// Do important work for 10 seconds
+	time.Sleep(10 * time.Second)
+
+	n2 := common.NewNotification("Finished a long running task", common.SUCCESS)
+	notificationChannel <- n2
+}

--- a/pkg/integration/hosts.go
+++ b/pkg/integration/hosts.go
@@ -1,0 +1,51 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"net"
+)
+
+type Host struct {
+	Name   string `json:"name"`
+	Ip     net.IP `json:"ip"`
+	Cpu    int    `json:"cpu"`
+	Memory int    `json:"memory"`
+	Disk   int    `json:"disk"`
+	Type   string `json:"type"`
+}
+
+func GetHosts() ([]Host, error) {
+	hostList := []Host{
+		Host{
+			Name:   "host-01",
+			Ip:     net.ParseIP("192.168.10.1"),
+			Cpu:    25,
+			Memory: 128,
+			Disk:   1024,
+			Type:   "Master",
+		},
+		Host{
+			Name:   "host-02",
+			Ip:     net.ParseIP("192.168.10.2"),
+			Cpu:    25,
+			Memory: 128,
+			Disk:   1024,
+			Type:   "Master",
+		},
+	}
+
+	return hostList, nil
+}

--- a/pkg/server/handler_helpers.go
+++ b/pkg/server/handler_helpers.go
@@ -1,0 +1,30 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+func respondWithJson(w http.ResponseWriter, obj interface{}) {
+	resp := ApiResponse{Data: obj}
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		log.Fatal(err)
+		respondWithJson(w, "FAIL")
+	}
+}

--- a/pkg/server/handler_helpers.go
+++ b/pkg/server/handler_helpers.go
@@ -20,11 +20,29 @@ import (
 	"net/http"
 )
 
-func respondWithJson(w http.ResponseWriter, obj interface{}) {
+func UnknownError(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), 500)
+}
+
+func RespondWithJson(w http.ResponseWriter, obj interface{}) {
 	resp := ApiResponse{Data: obj}
 	err := json.NewEncoder(w).Encode(resp)
 	if err != nil {
 		log.Fatal(err)
-		respondWithJson(w, "FAIL")
+		UnknownError(w, err)
 	}
+}
+
+func RespondWithError(w http.ResponseWriter, err error, code ...int) {
+	if len(code) > 0 {
+		w.WriteHeader(code[0])
+	}
+
+	resp := ApiErrorResponse{Error: err.Error()}
+	err = json.NewEncoder(w).Encode(resp)
+
+	if err != nil {
+		UnknownError(w, err)
+	}
+
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -1,0 +1,51 @@
+// Copyright 2019, Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/metalkube/facet/pkg/common"
+	"github.com/metalkube/facet/pkg/integration"
+	"log"
+	"net/http"
+)
+
+func HostsHandler(w http.ResponseWriter, r *http.Request) {
+	hostList, err := integration.GetHosts()
+	// TODO: Implement a real JSON error handler
+	if err != nil {
+		log.Print(err)
+	}
+	respondWithJson(w, hostList)
+}
+
+// This is an example of a REST API endpoint handler which will trigger a long
+// running task.  It takes a Notification channel as an argument, and returns a
+// standard HTTP handler.  The idea is to create a closure over the notification
+// channel.  When registering your handler with the router, you might do
+// something like:
+//
+//   router.HandleFunc("/some-endpoint", LongRunningTaskHandler(notificationChannel))
+//
+//  See pkg/server/server.go for an example.
+//
+// In the body itself, you are expected to start the actual long-running task in
+// a go routine, and quickly respond with a 2xx.
+func LongRunningTaskHandler(notificationChannel chan common.Notification) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		response := "OK"
+		go integration.PerformLongTask(notificationChannel)
+		respondWithJson(w, response)
+	}
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -49,3 +49,18 @@ func LongRunningTaskHandler(notificationChannel chan common.Notification) http.H
 		RespondWithJson(w, response)
 	}
 }
+
+func BootstrapVMHandler(notificationChannel chan common.Notification) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "", http.StatusMethodNotAllowed)
+			return
+		}
+
+		go integration.CreateBootstrapVM(notificationChannel)
+
+		RespondWithJson(w, "Request accepted")
+
+	}
+
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -27,7 +27,7 @@ func HostsHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Print(err)
 	}
-	respondWithJson(w, hostList)
+	RespondWithJson(w, hostList)
 }
 
 // This is an example of a REST API endpoint handler which will trigger a long
@@ -46,6 +46,6 @@ func LongRunningTaskHandler(notificationChannel chan common.Notification) http.H
 	return func(w http.ResponseWriter, r *http.Request) {
 		response := "OK"
 		go integration.PerformLongTask(notificationChannel)
-		respondWithJson(w, response)
+		RespondWithJson(w, response)
 	}
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -15,120 +15,39 @@
 package server
 
 import (
-	"encoding/json"
-	"github.com/satori/go.uuid"
-	"net"
+	"github.com/gorilla/mux"
+	"github.com/metalkube/facet/pkg/common"
+	"github.com/rakyll/statik/fs"
 	"net/http"
-	"time"
 )
 
-type Host struct {
-	Name   string `json:"name"`
-	Ip     net.IP `json:"ip"`
-	Cpu    int    `json:"cpu"`
-	Memory int    `json:"memory"`
-	Disk   int    `json:"disk"`
-	Type   string `json:"type"`
+func ApiRouter(router *mux.Router, notificationChannel chan common.Notification) {
+	router.Use(jsonMiddleware)
+
+	router.HandleFunc("/hosts", HostsHandler)
+	router.HandleFunc("/long", LongRunningTaskHandler(notificationChannel))
 }
 
-type ApiResponse struct {
-	Data interface{} `json:"data"`
-}
+func CreateRouter(notificationChannel chan common.Notification, websocketWorker *WebsocketWorker) *mux.Router {
+	router := mux.NewRouter()
 
-type NotificationStatus int
+	api := router.PathPrefix("/api").Subrouter()
+	ApiRouter(api, notificationChannel)
 
-const (
-	SUCCESS NotificationStatus = 0
-	RUNNING NotificationStatus = 1
-	FAILURE NotificationStatus = 2
-)
+	router.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		ServeWS(websocketWorker, w, r)
+	})
 
-func (ns NotificationStatus) String() string {
-	values := [...]string{
-		"SUCCESS",
-		"RUNNING",
-		"FAILURE",
-	}
-	if ns < SUCCESS || ns > FAILURE {
-		return "Unknown"
+	// Attempt to get the statik-built bundle
+	statikFS, err := fs.New()
+
+	if err != nil {
+		// Statik data isn't present, serve files from './build'
+		statikFS = http.Dir("./build/")
 	}
 
-	return values[ns]
-}
+	staticFileHandler := http.StripPrefix("/", http.FileServer(statikFS))
+	router.PathPrefix("/").Handler(staticFileHandler).Methods("GET")
 
-func (ns NotificationStatus) MarshalJSON() ([]byte, error) {
-	return json.Marshal(ns.String())
-}
-
-type Notification struct {
-	Id        string             `json:"id"`
-	Message   string             `json:"message"`
-	Status    NotificationStatus `json:"status"`
-	Timestamp time.Time          `json:"timestamp"`
-}
-
-func NewNotification(message string, status NotificationStatus) Notification {
-	uuid := uuid.NewV4()
-	return Notification{
-		Id:        uuid.String(),
-		Message:   message,
-		Status:    status,
-		Timestamp: time.Now(),
-	}
-}
-
-func HostsHandler(w http.ResponseWriter, r *http.Request) {
-	hostList := [2]Host{
-		Host{
-			Name:   "host-01",
-			Ip:     net.ParseIP("192.168.10.1"),
-			Cpu:    25,
-			Memory: 128,
-			Disk:   1024,
-			Type:   "Master",
-		},
-		Host{
-			Name:   "host-02",
-			Ip:     net.ParseIP("192.168.10.2"),
-			Cpu:    25,
-			Memory: 128,
-			Disk:   1024,
-			Type:   "Master",
-		},
-	}
-	respondWithJson(w, hostList)
-}
-
-// This is an example of a task that might take a while to finish.  It takes a
-// Notification channel as an argument.  You can use this channel to send
-// Notification messages to the browser.
-func performLongTask(notificationChannel chan Notification) {
-	n := NewNotification("Started a long running task", RUNNING)
-	notificationChannel <- n
-
-	// Do important work for 10 seconds
-	time.Sleep(10 * time.Second)
-
-	n2 := NewNotification("Finished a long running task", SUCCESS)
-	notificationChannel <- n2
-}
-
-// This is an example of a REST API endpoint handler which will trigger a long
-// running task.  It takes a Notification channel as an argument, and returns a
-// standard HTTP handler.  The idea is to create a closure over the notification
-// channel.  When registering your handler with the router, you might do
-// something like:
-//
-//   router.HandleFunc("/some-endpoint", LongRunningTaskHandler(notificationChannel))
-//
-//  See pkg/server/server.go for an example.
-//
-// In the body itself, you are expected to start the actual long-running task in
-// a go routine, and quickly respond with a 2xx.
-func LongRunningTaskHandler(notificationChannel chan Notification) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		response := "OK"
-		go performLongTask(notificationChannel)
-		respondWithJson(w, response)
-	}
+	return router
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -26,6 +26,7 @@ func ApiRouter(router *mux.Router, notificationChannel chan common.Notification)
 
 	router.HandleFunc("/hosts", HostsHandler)
 	router.HandleFunc("/long", LongRunningTaskHandler(notificationChannel))
+	router.HandleFunc("/bootstrap-vm", BootstrapVMHandler(notificationChannel))
 }
 
 func CreateRouter(notificationChannel chan common.Notification, websocketWorker *WebsocketWorker) *mux.Router {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"encoding/json"
 	"github.com/metalkube/facet/pkg/common"
 	_ "github.com/metalkube/facet/statik"
 	"log"
@@ -36,15 +35,6 @@ func jsonMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		next.ServeHTTP(w, r)
 	})
-}
-
-func respondWithJson(w http.ResponseWriter, obj interface{}) {
-	resp := ApiResponse{Data: obj}
-	err := json.NewEncoder(w).Encode(resp)
-	if err != nil {
-		log.Fatal(err)
-		respondWithJson(w, "FAIL")
-	}
 }
 
 func (s *Server) Start() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,7 +48,7 @@ func respondWithJson(w http.ResponseWriter, obj interface{}) {
 }
 
 func (s *Server) Start() {
-	notificationChannel := make(chan common.Notification, 5)
+	notificationChannel := common.NewNotificationChannel()
 	websocketWorker := NewWebsocketWorker(notificationChannel)
 
 	router := CreateRouter(notificationChannel, websocketWorker)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,6 +29,10 @@ type ApiResponse struct {
 	Data interface{} `json:"data"`
 }
 
+type ApiErrorResponse struct {
+	Error interface{} `json:"error"`
+}
+
 func jsonMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/websocket.go
+++ b/pkg/server/websocket.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/gorilla/websocket"
+	"github.com/metalkube/facet/pkg/common"
 	"log"
 	"net/http"
 )
@@ -10,7 +11,7 @@ type Client struct {
 	conn *websocket.Conn
 }
 
-func (c Client) send(notification Notification) {
+func (c Client) send(notification common.Notification) {
 	log.Print("Sending message to client: ", notification.Id)
 	err := c.conn.WriteJSON(notification)
 	if err != nil {
@@ -22,12 +23,12 @@ func (c Client) send(notification Notification) {
 // The WebSocket Worker will be a long-running go routine which registers
 // websocket clients connections, and broadcasts notification to connected clients.
 type WebsocketWorker struct {
-	clients    []*Client         // Connected clients
-	broadcasts chan Notification // A channel of messages to be sent to all clients
-	register   chan *Client      // A channel of websocket clients trying to connect
+	clients    []*Client                // Connected clients
+	broadcasts chan common.Notification // A channel of messages to be sent to all clients
+	register   chan *Client             // A channel of websocket clients trying to connect
 }
 
-func NewWebsocketWorker(broadcastChannel chan Notification) *WebsocketWorker {
+func NewWebsocketWorker(broadcastChannel chan common.Notification) *WebsocketWorker {
 	return &WebsocketWorker{
 		clients:    make([]*Client, 0),
 		register:   make(chan *Client, 0),


### PR DESCRIPTION
You are expected to run the facet server on the dev-scripts host.

There is a [PR](https://github.com/metalkube/dev-scripts/pull/66) for dev-scripts that installs facet.

Depends on #30 