### PR TITLE
Introduced patternfly empty state for Baremetal inventory

### DIFF
--- a/src/components/HostsEmptyState.tsx
+++ b/src/components/HostsEmptyState.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  Title,
+  EmptyState,
+  EmptyStateBody,
+  Bullseye
+} from '@patternfly/react-core';
+
+class HostsEmptyState extends React.Component {
+  render(): JSX.Element {
+    return (
+      <Bullseye>
+        <EmptyState>
+          <Title size="lg">No hosts connected</Title>
+          <EmptyStateBody>
+            Connect at least 3 hosts to your cluster to pool
+            <br />
+            together resources and start running workloads.
+          </EmptyStateBody>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
+}
+
+export default HostsEmptyState;

--- a/src/components/HostsTable.tsx
+++ b/src/components/HostsTable.tsx
@@ -2,6 +2,7 @@ import React, { FC, Fragment } from 'react';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { Bullseye } from '@patternfly/react-core';
 import { HostTableRows } from '../models/hosts';
+import HostsEmptyState from './HostsEmptyState';
 
 interface Props {
   hostRows: HostTableRows;
@@ -42,9 +43,10 @@ const HostsTable: FC<Props> = ({
     <Fragment>
       <Table rows={hostRows} cells={columns} aria-label="Hosts table">
         <TableHeader />
-        {!loadingHosts && <TableBody />}
+        {!loadingHosts && !!hostRows.length && <TableBody />}
       </Table>
       {loadingHosts && <Bullseye>Loading...</Bullseye>}
+      {!loadingHosts && !hostRows.length && <HostsEmptyState />}
     </Fragment>
   );
 };


### PR DESCRIPTION
Implemented HostsEmptyState component for Baremetal inventory.
WIP due to need assistance with aligning the EmptyState component
to centre. Styling margin: 0 auto; works, so need to identify
a patternfly component or class that implements that styling.