### PR TITLE
Introduce pull secret fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.vscode
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -8,14 +8,18 @@
     "@patternfly/react-icons": "^3.0.0",
     "@patternfly/react-table": "0.4.18",
     "@types/jest": "23.3.13",
+    "@types/lodash": "^4.14.121",
     "@types/node": "10.12.18",
     "@types/react": "16.7.20",
     "@types/react-dom": "16.0.11",
     "@types/react-redux": "^7.0.1",
+    "@types/yup": "^0.26.9",
     "axios": "^0.18.0",
     "bootstrap-sass": "^3.4.0",
     "eslint": "5.6.0",
     "font-awesome": "^4.7.0",
+    "formik": "^1.5.1",
+    "lodash": "^4.17.11",
     "node-sass": "^4.11.0",
     "patternfly": "^3.59.1",
     "patternfly-react": "^2.29.10",
@@ -29,7 +33,8 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "typesafe-actions": "^3.0.0",
-    "typescript": "3.2.4"
+    "typescript": "3.2.4",
+    "yup": "^0.26.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/pkg/integration/pull_secret.go
+++ b/pkg/integration/pull_secret.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const authTokenRequestURL = "https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/token"
+const pullSecretRequestURL = "https://api.openshift.com/api/accounts_mgmt/v1/access_token"
+
+type DeveloperTokenResponse struct {
+	ExpiresIn        int    `json:"expires_in"`
+	RefreshExpiresIn int    `json:"refresh_expires_in"`
+	RefreshToken     string `json:"refresh_token"`
+	TokenType        string `json:"token_type"`
+	NotBeforePolicy  int    `json:"not-before-policy"`
+	SessionState     string `json:"session_state"`
+	AccessToken      string `json:"access_token"`
+}
+
+type DeveloperTokenErrorReponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+type PullSecretErrorResponse struct {
+	ID     string `json:"id"`
+	Kind   string `json:"kind"`
+	Href   string `json:"href"`
+	Code   string `json:"code"`
+	Reason string `json:"reason"`
+}
+
+func FetchAuthToken(username string, password string) (tokenData DeveloperTokenResponse, err error) {
+	resp, err := http.PostForm(authTokenRequestURL, url.Values{
+		"grant_type": {"password"},
+		"client_id":  {"uhc"},
+		"username":   {username},
+		"password":   {password},
+	})
+	if err != nil {
+		return tokenData, err
+	}
+
+	if resp.StatusCode != 200 {
+		var errorData DeveloperTokenErrorReponse
+		err = json.NewDecoder(resp.Body).Decode(&errorData)
+		if err != nil {
+			return tokenData, err
+		}
+		return tokenData, fmt.Errorf("%s: %s", resp.Status, errorData.ErrorDescription)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&tokenData)
+	if err != nil {
+		return tokenData, err
+	}
+
+	return tokenData, nil
+}
+
+func FetchPullSecret(tokenData DeveloperTokenResponse) (pullSecret map[string]interface{}, err error) {
+	req, err := http.NewRequest("POST", pullSecretRequestURL, nil)
+	req.Header.Add("accept", "application/json")
+	req.Header.Add("authorization", "bearer "+tokenData.AccessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return pullSecret, err
+	}
+
+	if resp.StatusCode != 200 {
+		var errorData PullSecretErrorResponse
+		err = json.NewDecoder(resp.Body).Decode(&errorData)
+		if err != nil {
+			return pullSecret, err
+		}
+		return pullSecret, fmt.Errorf("%s: %s", resp.Status, errorData.Reason)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&pullSecret)
+	if err != nil {
+		return pullSecret, err
+	}
+
+	return pullSecret, nil
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -28,6 +28,7 @@ func ApiRouter(router *mux.Router, notificationChannel chan common.Notification)
 	router.HandleFunc("/hosts", HostsHandler)
 	router.HandleFunc("/long", LongRunningTaskHandler(notificationChannel))
 	router.HandleFunc("/bootstrap-vm", BootstrapVMHandler(notificationChannel))
+	router.HandleFunc("/cluster-definition", CreateClusterDefinition).Methods("POST")
 }
 
 func CreateRouter(notificationChannel chan common.Notification, websocketWorker *WebsocketWorker) *mux.Router {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,10 +15,11 @@
 package server
 
 import (
-	"github.com/metalkube/facet/pkg/common"
-	_ "github.com/metalkube/facet/statik"
 	"log"
 	"net/http"
+
+	"github.com/metalkube/facet/pkg/common"
+	_ "github.com/metalkube/facet/statik"
 )
 
 type Server struct {
@@ -53,8 +54,7 @@ func (s *Server) Start() {
 	err := http.ListenAndServe(":"+s.Port, router)
 
 	if err != nil {
-		log.Fatal("Failed to start server")
-		log.Fatal(err)
+		log.Fatal("Failed to start server: ", err)
 	}
 
 }

--- a/src/api/clusterDefinition.ts
+++ b/src/api/clusterDefinition.ts
@@ -1,0 +1,32 @@
+import axios, { AxiosPromise } from 'axios';
+import { mapKeys, snakeCase } from 'lodash';
+
+import { ClusterDefinition } from '../models/clusterDefinition';
+import { ApiResponse } from './index';
+
+type PostClusterDefinitionApiRequestKeys =
+  | 'cluster_name'
+  | 'dns_domain'
+  | 'username'
+  | 'password'
+  | 'pull_secret';
+
+type PostClusterDefinitionApiRequestData = {
+  [T in PostClusterDefinitionApiRequestKeys]: string
+};
+
+type PostClusterDefinitionApiResponse = AxiosPromise<
+  ApiResponse<ClusterDefinition>
+>;
+
+const snakeCaseKeys = (
+  values: ClusterDefinition
+): PostClusterDefinitionApiRequestData =>
+  mapKeys(values, (value, key) =>
+    snakeCase(key)
+  ) as PostClusterDefinitionApiRequestData;
+
+export const postInstallConfig = (
+  values: ClusterDefinition
+): PostClusterDefinitionApiResponse =>
+  axios.post('/api/cluster-definition', snakeCaseKeys(values));

--- a/src/components/createCluster/PullSecretFields.tsx
+++ b/src/components/createCluster/PullSecretFields.tsx
@@ -1,18 +1,16 @@
 import React, { FC, Fragment } from 'react';
-import { FormGroup, TextArea, TextContent, Text } from '@patternfly/react-core';
+import { Field } from 'formik';
+import { TextContent, Text } from '@patternfly/react-core';
 
 import ExternalLink from '../ui/ExternalLink';
+import { TextArea } from '../ui/formik';
 
 interface PullSecretFieldsProps {
   onProvideCredentials: () => void;
-  handlePullSecretChange: (value: string) => void;
-  pullSecret: string;
 }
 
 const PullSecretFields: FC<PullSecretFieldsProps> = ({
-  onProvideCredentials,
-  handlePullSecretChange,
-  pullSecret
+  onProvideCredentials
 }: PullSecretFieldsProps): JSX.Element => (
   <Fragment>
     <TextContent>
@@ -28,20 +26,14 @@ const PullSecretFields: FC<PullSecretFieldsProps> = ({
         instead.
       </Text>
     </TextContent>
-    <FormGroup
+    <Field
+      component={TextArea}
       label="Pull secret"
-      fieldId="create-cluster-pull-secret"
+      name="pullSecret"
+      id="create-cluster-pull-secret"
+      aria-label="Pull secret"
       isRequired
-    >
-      <TextArea
-        id="create-cluster-pull-secret"
-        name="pullSecret"
-        value={pullSecret}
-        onChange={handlePullSecretChange}
-        aria-label="Pull secret"
-        isRequired
-      />
-    </FormGroup>
+    />
   </Fragment>
 );
 export default PullSecretFields;

--- a/src/components/createCluster/RedHatAccountFields.tsx
+++ b/src/components/createCluster/RedHatAccountFields.tsx
@@ -1,27 +1,16 @@
 import React, { FC, Fragment } from 'react';
-import {
-  FormGroup,
-  TextInput,
-  TextContent,
-  Text
-} from '@patternfly/react-core';
+import { Field } from 'formik';
+import { TextContent, Text } from '@patternfly/react-core';
 
 import ExternalLink from '../ui/ExternalLink';
+import { TextInput } from '../ui/formik';
 
 interface RedHatAccountFieldsProps {
   onProvidePullSecret: () => void;
-  handleUsernameChange: (value: string) => void;
-  handlePasswordChange: (value: string) => void;
-  username: string;
-  password: string;
 }
 
 const RedHatAccountFields: FC<RedHatAccountFieldsProps> = ({
-  onProvidePullSecret,
-  handleUsernameChange,
-  handlePasswordChange,
-  username,
-  password
+  onProvidePullSecret
 }: RedHatAccountFieldsProps): JSX.Element => (
   <Fragment>
     <TextContent>
@@ -38,28 +27,21 @@ const RedHatAccountFields: FC<RedHatAccountFieldsProps> = ({
         instead.
       </Text>
     </TextContent>
-    <FormGroup label="Username" fieldId="create-cluster-username" isRequired>
-      <TextInput
-        type="text"
-        id="create-cluster-username"
-        name="username"
-        aria-describedby="create-cluster-username-helper"
-        value={username}
-        onChange={handleUsernameChange}
-        isRequired
-      />
-    </FormGroup>
-    <FormGroup label="Password" fieldId="create-cluster-password" isRequired>
-      <TextInput
-        type="text"
-        id="create-cluster-password-domain"
-        name="password"
-        aria-describedby="create-cluster-password-helper"
-        value={password}
-        onChange={handlePasswordChange}
-        isRequired
-      />
-    </FormGroup>
+    <Field
+      component={TextInput}
+      label="Username"
+      id="create-cluster-username"
+      name="username"
+      isRequired
+    />
+    <Field
+      component={TextInput}
+      label="Password"
+      id="create-cluster-password"
+      name="password"
+      type="password"
+      isRequired
+    />
   </Fragment>
 );
 export default RedHatAccountFields;

--- a/src/components/createCluster/validationSchema.ts
+++ b/src/components/createCluster/validationSchema.ts
@@ -1,0 +1,18 @@
+import * as Yup from 'yup';
+
+export default Yup.object().shape({
+  clusterName: Yup.string().required('Required'),
+  DNSDomain: Yup.string().required('Required'),
+  pullSecret: Yup.string().when('$providePullSecret', {
+    is: true,
+    then: Yup.string().required('Required')
+  }),
+  username: Yup.string().when('$providePullSecret', {
+    is: false,
+    then: Yup.string().required('Required')
+  }),
+  password: Yup.string().when('$providePullSecret', {
+    is: false,
+    then: Yup.string().required('Required')
+  })
+});

--- a/src/components/ui/formik/TextArea.tsx
+++ b/src/components/ui/formik/TextArea.tsx
@@ -1,0 +1,54 @@
+import React, { Component, FormEvent } from 'react';
+import { FieldProps } from 'formik';
+import { FormGroup, TextArea as PFTextArea } from '@patternfly/react-core';
+
+interface Props extends FieldProps {
+  id: string;
+  label: string;
+  helperText?: string;
+  isRequired?: boolean;
+  isInline?: boolean;
+}
+
+export default class TextArea extends Component<Props> {
+  // PFTextInput introduces different onChange footprint, this fixes it
+  handleChange = (v: string, e: FormEvent<HTMLInputElement>): void =>
+    this.props.field.onChange(e);
+
+  render(): JSX.Element {
+    const {
+      field,
+      form: { touched, errors },
+      id,
+      label,
+      helperText,
+      isRequired = false,
+      isInline = false,
+      ...rest
+    }: Props = this.props;
+
+    const isValid =
+      !touched[field.name] || (!!touched[field.name] && !errors[field.name]);
+
+    return (
+      <FormGroup
+        label={label}
+        fieldId={id}
+        helperText={helperText}
+        helperTextInvalid={errors[field.name]}
+        isValid={isValid}
+        isRequired={isRequired}
+        isInline={isInline}
+      >
+        <PFTextArea
+          id={id}
+          isValid={isValid}
+          isRequired={isRequired}
+          {...field}
+          onChange={this.handleChange}
+          {...rest}
+        />
+      </FormGroup>
+    );
+  }
+}

--- a/src/components/ui/formik/TextInput.tsx
+++ b/src/components/ui/formik/TextInput.tsx
@@ -1,0 +1,63 @@
+import React, { Component, FormEvent } from 'react';
+import { FieldProps } from 'formik';
+import { FormGroup, TextInput as PFTextInput } from '@patternfly/react-core';
+
+interface Props extends FieldProps {
+  id: string;
+  label: string;
+  type?: string;
+  helperText?: string;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  isInline?: boolean;
+  isReadOnly?: boolean;
+}
+
+export default class TextInput extends Component<Props> {
+  // PFTextInput introduces different onChange footprint, this fixes it
+  handleChange = (v: string, e: FormEvent<HTMLInputElement>): void =>
+    this.props.field.onChange(e);
+
+  render(): JSX.Element {
+    const {
+      field,
+      form: { touched, errors, isSubmitting },
+      id,
+      label,
+      type = 'text',
+      helperText,
+      isRequired = false,
+      isDisabled = false,
+      isInline = false,
+      isReadOnly = false,
+      ...rest
+    }: Props = this.props;
+
+    const isValid =
+      !touched[field.name] || (!!touched[field.name] && !errors[field.name]);
+
+    return (
+      <FormGroup
+        label={label}
+        fieldId={id}
+        helperText={helperText}
+        helperTextInvalid={errors[field.name]}
+        isValid={isValid}
+        isRequired={isRequired}
+        isInline={isInline}
+      >
+        <PFTextInput
+          type={type}
+          id={id}
+          isValid={isValid}
+          isRequired={isRequired}
+          isDisabled={isDisabled || isSubmitting}
+          isReadOnly={isReadOnly}
+          {...field}
+          onChange={this.handleChange}
+          {...rest}
+        />
+      </FormGroup>
+    );
+  }
+}

--- a/src/components/ui/formik/index.tsx
+++ b/src/components/ui/formik/index.tsx
@@ -1,0 +1,2 @@
+export { default as TextInput } from './TextInput';
+export { default as TextArea } from './TextArea';

--- a/src/models/clusterDefinition.ts
+++ b/src/models/clusterDefinition.ts
@@ -1,0 +1,7 @@
+export interface ClusterDefinition {
+  clusterName: string;
+  DNSDomain: string;
+  username: string;
+  password: string;
+  pullSecret: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,13 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  integrity sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
@@ -1380,6 +1387,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.13.tgz#c81484b6f4ca007bb09887ed15ecb3286d58f928"
   integrity sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA==
 
+"@types/lodash@^4.14.121":
+  version "4.14.121"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.121.tgz#9327e20d49b95fc2bf983fc2f045b2c6effc80b9"
+  integrity sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==
+
 "@types/node@10.12.18":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
@@ -1422,6 +1434,11 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
   integrity sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==
+
+"@types/yup@^0.26.9":
+  version "0.26.9"
+  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.26.9.tgz#8a619ac4d2b8dcacb0d81345746018303b479919"
+  integrity sha512-C7HdLLs1ZNPbYeNsSX++fMosxWAwzVeUs9wc76XlKJrKvLEyNwXMDUjag75EVAPxlZ36YiRJ6iTy4zc5Dbtndw==
 
 "@typescript-eslint/eslint-plugin@^1.1.0":
   version "1.1.0"
@@ -3689,7 +3706,7 @@ create-react-context@<=0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-create-react-context@^0.2.3:
+create-react-context@^0.2.2, create-react-context@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
@@ -4114,6 +4131,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-gateway@^2.6.0:
   version "2.7.2"
@@ -5287,6 +5309,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+fn-name@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
+  integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+
 focus-trap-react@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-4.0.1.tgz#3cffd39341df3b2f546a4a2fe94cfdea66154683"
@@ -5370,6 +5397,21 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formik@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-1.5.1.tgz#ef5687e1ade5b1fe5f1d51435b422238aad107e9"
+  integrity sha512-FBWGBKQkcCE4d5b5l2fKccD9d1QxNxw/0bQTRvp3EjzA8Bnjmsm9H/Oy0375UA8P3FPmfJkF4cXLLdEqK7fP5A==
+  dependencies:
+    create-react-context "^0.2.2"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^2.5.5"
+    lodash "^4.17.11"
+    lodash-es "^4.17.11"
+    prop-types "^15.6.1"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.9.3"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5868,7 +5910,7 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -7425,6 +7467,11 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+lodash-es@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
+  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -9572,6 +9619,11 @@ prop-types@^15.6.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+property-expr@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
+  integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+
 proxy-addr@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
@@ -9850,6 +9902,11 @@ react-error-overlay@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.2.tgz#888957b884d4b25b083a82ad550f7aad96585394"
   integrity sha512-7kEBKwU9R8fKnZJBRa5RSIfay4KJwnYvKB6gODGicUmDSAhQJ7Tdnll5S0RLtYrzRfMVXlqYw61rzrSpP4ThLQ==
+
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-fontawesome@^1.6.1:
   version "1.6.1"
@@ -11251,6 +11308,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
+synchronous-promise@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.6.tgz#de76e0ea2b3558c1e673942e47e714a930fa64aa"
+  integrity sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==
+
 tabbable@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.2.tgz#f2d16cccd01f400e38635c7181adfe0ad965a4a2"
@@ -11387,6 +11449,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-warning@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
+  integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
+
 tippy.js@^3.2.0, tippy.js@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.4.1.tgz#f0eb3081824ad6c5d364336451ad77ae2f543da8"
@@ -11453,6 +11520,11 @@ topo@2.x.x:
   dependencies:
     hoek "4.x.x"
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 touch@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
@@ -11514,7 +11586,7 @@ tryer@^1.0.0:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -12394,3 +12466,15 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yup@^0.26.10:
+  version "0.26.10"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.26.10.tgz#3545839663289038faf25facfc07e11fd67c0cb1"
+  integrity sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    fn-name "~2.0.1"
+    lodash "^4.17.10"
+    property-expr "^1.5.0"
+    synchronous-promise "^2.0.5"
+    toposort "^2.0.2"


### PR DESCRIPTION
* Converts cluster definition form to using [Formik](https://jaredpalmer.com/formik/)
* Adds basic fields validation
* Introduces capabilities to submit the form to the respective API endpoint
* Introduces /api/install-config API endpoint

TODO:
* [x] Move install config handler(s) into a separate module
* [x] Move pullSecret and developers.redhat.com token fetching into a separate functions
* [x] Display error in the footer

Separate PR:
* Add client side validation for clusterName, DNSDomain, and pullSecret format
* Add state management for InstallConfig
* Persist install config on server side
* Add GET /api/install-config endpoint and handler to allow retrieving stored install config
